### PR TITLE
feat: add carryforward configuration to Codecov flags

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -11,6 +11,7 @@ on:
       - main
     paths:
       - 'client/**'
+  workflow_dispatch:
 
 jobs:
   client:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -11,6 +11,7 @@ on:
         - main
       paths:
         - 'server/**'
+  workflow_dispatch:
 
 jobs:
   server:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,13 @@ coverage:
     project:
       default:
         informational: true
-    patch:
+  patch:
       default:
         informational: true
+
+
+flags:
+  server:
+    carryforward: true
+  client:
+    carryforward: true


### PR DESCRIPTION
This commit introduces carryforward settings to the Codecov configuration,  enabling the 'server' and 'client' flags to utilize carryforward. This  improves the consistency of coverage reporting across different builds.

Changes made:
- Updated the `codecov.yml` file to include `carryforward` under both  `server` and `client` flags.
- Ensured that the `patch` section maintains its default settings.

These additions allow for a more robust tracking of code coverage over  time, particularly when running multiple builds with incremental changes.

### Linked issues

- Closes #14