### PR TITLE
chore(tests): increase test coverage in server module

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -61,6 +61,8 @@ dependencies {
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("io.github.hakky54:logcaptor:2.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/server/src/test/kotlin/no/uyqn/server/ServerApplicationTests.kt
+++ b/server/src/test/kotlin/no/uyqn/server/ServerApplicationTests.kt
@@ -3,11 +3,9 @@ package no.uyqn.server
 import no.uyqn.server.config.DotenvInitializer
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
 @SpringBootTest
-@ActiveProfiles("test")
 @ContextConfiguration(initializers = [DotenvInitializer::class])
 class ServerApplicationTests {
     @Test

--- a/server/src/test/kotlin/no/uyqn/server/config/DotenvInitializerTest.kt
+++ b/server/src/test/kotlin/no/uyqn/server/config/DotenvInitializerTest.kt
@@ -1,0 +1,62 @@
+package no.uyqn.server.config
+
+import io.github.cdimascio.dotenv.Dotenv
+import io.github.cdimascio.dotenv.DotenvEntry
+import io.github.cdimascio.dotenv.dotenv
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
+import nl.altindag.log.LogCaptor
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ConfigurableApplicationContext
+import kotlin.test.assertEquals
+
+class DotenvInitializerTest {
+    @MockK
+    private lateinit var mockApplicationContext: ConfigurableApplicationContext
+
+    @MockK
+    private lateinit var mockDotenv: Dotenv
+
+    private lateinit var logCaptor: LogCaptor
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+        mockkStatic("io.github.cdimascio.dotenv.Dotenv")
+
+        logCaptor = LogCaptor.forClass(DotenvInitializer::class.java)
+
+        every {
+            dotenv {
+                directory = any(String::class)
+                ignoreIfMissing = true
+                ignoreIfMalformed = true
+            }
+        } returns mockDotenv
+    }
+
+    @Test
+    fun `should load environment variables from the dotenv file in the root directory of the project`() {
+        val mockEntries = mutableSetOf(DotenvEntry("key1", "value1"), DotenvEntry("key2", "value2"))
+        every { mockDotenv.entries(Dotenv.Filter.DECLARED_IN_ENV_FILE) } returns mockEntries
+
+        every { mockApplicationContext.environment.systemProperties } returns mutableMapOf()
+
+        DotenvInitializer().initialize(mockApplicationContext)
+
+        assertEquals("value1", mockApplicationContext.environment.systemProperties["key1"])
+        assertEquals("value2", mockApplicationContext.environment.systemProperties["key2"])
+    }
+
+    @Test
+    fun `should log a warning if no dotenv file is found`() {
+        every { mockDotenv.entries(Dotenv.Filter.DECLARED_IN_ENV_FILE) } returns emptySet()
+
+        DotenvInitializer().initialize(mockApplicationContext)
+
+        assertEquals("No .env file found in ${System.getProperty("user.dir")}", logCaptor.warnLogs.first())
+    }
+}


### PR DESCRIPTION
- Added new testing dependencies:
  - `mockk:1.13.13` for mocking in Kotlin tests
  - `logcaptor:2.9.3` for capturing and validating log output during tests

- Updated the `ServerApplicationTests` to remove the `@ActiveProfiles` annotation as it was not necessary, ensuring it uses the default profile for testing.

- Created a new test class `DotenvInitializerTest` with the following features:
  - **Test Setup**: Utilizes MockK annotations and static mocking to initialize a mocked Dotenv instance.
  - **Test Cases**:
    - **Environment Variable Loading**: Tests that environment variables from a dotenv file located in the root directory are correctly loaded into the application context.
    - **Logging on Missing Dotenv**: Tests if a warning is logged when no dotenv file is found, ensuring appropriate behavior and logging during runtime.

This commit aims to enhance the reliability and maintainability of the server module by improving its test coverage and ensuring robust configuration loading.

### Linked Issues
- Closes #16 