### PR TITLE
chore(migration): add initial admin user and roles

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -9,8 +9,7 @@ if (!linkedIssuePattern.test(prBody)) {
     
     For more information, see [linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).`);
     markdown(`
-    ### Linked issues
-    
+    ### Linked issue(s)
     - Closes #${issueNumber}
     `);
 }

--- a/server/src/main/resources/db/migration/V2024_11_25_01__insert_admin_user.sql
+++ b/server/src/main/resources/db/migration/V2024_11_25_01__insert_admin_user.sql
@@ -1,0 +1,9 @@
+WITH inserted_user AS (
+    INSERT INTO users (email, username, password)
+    VALUES ('uy.nguyen2@visma.com','uy.nguyen2','$argon2id$v=19$m=16384,t=2,p=1$sUVYaZEp1u53CF+TToJ1wg$VtnF0NZBclXtB6HgMJI3bCHYP50LTabtrTGTQXbbg+0')
+    RETURNING id
+)
+
+INSERT INTO user_roles (user_id, role)
+SELECT id, role
+FROM inserted_user, (VALUES ('USER'), ('ADMIN')) AS roles(role);


### PR DESCRIPTION
This pull request introduces a critical enhancement to the user management system by adding an initial admin user along with its roles. It includes a SQL migration script designed to establish administrative capabilities immediately after deployment.

### Summary of Changes:
- **Migration Script**: 
  - A new SQL migration script has been created that inserts an initial admin user into the `users` table.
    - **User Details**:
      - Email: `uy.nguyen2@visma.com`
      - Username: `uy.nguyen2`
      - Password: Securely hashed using Argon2.
  - After insertion, the script retrieves the ID of the newly created user and associates it with two essential roles:
    - 'USER'
    - 'ADMIN'
    
This foundational setup is crucial for providing immediate administrative functionality and ensuring that the application has necessary access controls from the start.

### Related Changes:
This PR is part of the `2.2.0` release cycle, which includes:
- Improvement of the GitHub Actions release workflow.
- Addition of integration tests for user authentication.
- Implementation of OAuth2 and JWT authentication.
- User registration features using R2DBC.
- Various enhancements and refactors for increased code quality and test coverage.

### Linked issue(s)
- Closes #31

Please review the changes and consider merging this feature to ensure our application is equipped with an initial admin user that supports essential administrative functionalities.